### PR TITLE
ノートを編集しても、日付の降順にならない #1

### DIFF
--- a/src/components/Main.jsx
+++ b/src/components/Main.jsx
@@ -7,7 +7,7 @@ const Main = ({ activeNote, onUpdateNote }) => {
     onUpdateNote({
       ...activeNote,
       [key]: value,
-      modDate: Date.now,
+      modDate: Date.now(),
     });
   };
 


### PR DESCRIPTION
Date.now()メソッドの"()"が抜けていることが原因でした。